### PR TITLE
scd30: Add force recalibration with reference action

### DIFF
--- a/esphome/components/scd30/automation.h
+++ b/esphome/components/scd30/automation.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "scd30.h"
+
+namespace esphome {
+namespace scd30 {
+
+template<typename... Ts> class ForceRecalibrationWithReference : public Action<Ts...>, public Parented<SCD30Component> {
+ public:
+  void play(Ts... x) override {
+    if (this->value_.has_value()) {
+      this->parent_->force_recalibration_with_reference(this->value_.value(x...));
+    }
+  }
+
+ protected:
+  TEMPLATABLE_VALUE(uint16_t, value)
+};
+
+}  // namespace scd30
+}  // namespace esphome

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -20,6 +20,8 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
   }
   void set_temperature_offset(float offset) { temperature_offset_ = offset; }
   void set_update_interval(uint16_t interval) { update_interval_ = interval; }
+  bool force_recalibration_with_reference(uint16_t co2_reference);
+  uint16_t get_forced_calibration_reference();
 
   void setup() override;
   void update();
@@ -33,6 +35,7 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
     COMMUNICATION_FAILED,
     FIRMWARE_IDENTIFICATION_FAILED,
     MEASUREMENT_INIT_FAILED,
+    FORCE_RECALIBRATION_FAILED,
     UNKNOWN
   } error_code_{UNKNOWN};
   bool enable_asc_{true};

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -1,6 +1,7 @@
-from esphome import core
+from esphome import automation, core
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.automation import maybe_simple_id
 from esphome.components import i2c, sensor
 from esphome.components import sensirion_common
 from esphome.const import (
@@ -9,6 +10,7 @@ from esphome.const import (
     CONF_TEMPERATURE,
     CONF_CO2,
     CONF_UPDATE_INTERVAL,
+    CONF_VALUE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
@@ -24,6 +26,11 @@ AUTO_LOAD = ["sensirion_common"]
 scd30_ns = cg.esphome_ns.namespace("scd30")
 SCD30Component = scd30_ns.class_(
     "SCD30Component", cg.Component, sensirion_common.SensirionI2CDevice
+)
+
+# Actions
+ForceRecalibrationWithReference = scd30_ns.class_(
+    "ForceRecalibrationWithReference", automation.Action
 )
 
 CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
@@ -106,3 +113,22 @@ async def to_code(config):
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
         cg.add(var.set_temperature_sensor(sens))
+
+@automation.register_action(
+    "scd30.force_recalibration_with_reference",
+    ForceRecalibrationWithReference,
+    maybe_simple_id(
+        {
+            cv.GenerateID(): cv.use_id(SCD30Component),
+            cv.Required(CONF_VALUE): cv.templatable(
+                cv.int_range(min=400, max=2000, max_included=True)
+            ),
+        }
+    ),
+)
+async def scd30_force_recalibration_with_reference_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint16)
+    cg.add(var.set_value(template_))
+    return var

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2981,6 +2981,9 @@ button:
   - platform: template
     name: Start calibration
     on_press:
+      - scd30.force_recalibration_with_reference:
+          value: 419
+          id: scd30
       - scd4x.perform_forced_calibration:
           value: 419
           id: scd40


### PR DESCRIPTION
The SCD30 co2 sensor likely needs to be calibrated to adjust for individual devices. Support the built in force calibration with reference feature detailed here:
  https://learn.adafruit.com/adafruit-scd30/field-calibration

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
